### PR TITLE
added __future__ for print compatibility between 2 and 3

### DIFF
--- a/modules/irc.py
+++ b/modules/irc.py
@@ -15,6 +15,7 @@
 #         ]
 #     }
 # }
+from __future__ import print_function
 import sys, re
 
 handler_dict = {

--- a/ratbox-monitor.py
+++ b/ratbox-monitor.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys, json, argparse, time, socket, errno
 import multiprocessing
 import modules.connect as connect


### PR DESCRIPTION
This will allow us to safely print between python 2 and 3.  I imagine most of our clients will be fairly old and reluctant to change Python versions (especially if it needs to be done by hand on say, CentOS).